### PR TITLE
chore(context): add master repo context & Copilot instructions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owners
+* @goodbooks/maintainers
+
+# Areas
+src/**/*.py @goodbooks/backend
+src/**/*.{ts,tsx,js,jsx} @goodbooks/frontend
+terraform/** @goodbooks/infra

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -121,3 +121,9 @@ Use the integrated VS Code tasks for common operations:
 3. **API typing**: Ensure proper TypeScript interfaces match Python models
 4. **Performance**: Large book lists should use virtualization
 5. **Security**: Never expose API keys in frontend code
+
+## 📦 Additional Context
+- See `PROJECT_BRIEF.md`, `CODEMAP.md`, and `ARCHITECTURE.md` for repository overview.
+- Consult `AGENTS.md` for structure, coding standards, and commands.
+- Run `npm test` and `python -m pytest` before committing.
+- Use commit style `type(scope): summary`.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "src/**/*.py"
+---
+- Follow PEP8 and format with `black`.
+- Annotate functions with type hints.
+- FastAPI routers belong under `src/api` or `src/news/api`.
+- Run `python -m pytest` before committing.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,7 @@
+---
+applyTo: "src/**/*.{ts,tsx,js,jsx}"
+---
+- Use React functional components with TypeScript typings.
+- Prefer Tailwind CSS utilities; avoid inline styles.
+- Keep components small and documented with JSDoc.
+- Run `npm test` and `npm run lint` when modifying files.

--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -1,0 +1,6 @@
+---
+applyTo: "terraform/**"
+---
+- Format with `terraform fmt` before commit.
+- Validate with `terraform validate`.
+- Keep secrets in variables and `.tfvars`, never commit real credentials.

--- a/.github/prompts/repo-context.md
+++ b/.github/prompts/repo-context.md
@@ -1,0 +1,13 @@
+# Repo Context
+
+Consult these docs before coding:
+- `PROJECT_BRIEF.md`
+- `CODEMAP.md`
+- `ARCHITECTURE.md`
+- `API_CATALOG.md`
+- `DATA_MODEL.md`
+- `TEST_MATRIX.md`
+- `SECURITY.md`
+- `BENCHMARKS.md`
+
+Follow `.github/copilot-instructions.md`, `AGENTS.md`, and scoped rules in `.github/instructions/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Handbook
+
+Repository guidance for AI and human contributors.
+
+## Directory Overview
+- `src/` – application code (frontend and backend)
+- `tests/` – unit and integration tests
+- `scripts/` – utility scripts
+- `terraform/` – infrastructure as code
+
+## Coding Standards
+- **Python**: format with `black`, type hints required
+- **TypeScript/JS**: use ESLint and Prettier, React functional components
+- **Terraform**: run `terraform fmt`
+
+## Build & Test Commands
+- `npm test` – frontend tests
+- `npm run lint` – frontend linting
+- `python -m pytest` – backend tests
+- `pre-commit run --all-files` – lint/format all files
+- `terraform validate` – infrastructure validation
+
+## Prompt Patterns
+- Scope requests to a single concern
+- Provide file paths and snippets for context
+- Use numbered steps for complex changes
+- Run tests and linters after edits

--- a/API_CATALOG.md
+++ b/API_CATALOG.md
@@ -1,0 +1,24 @@
+# API Catalog
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/` | API info | None |
+| GET | `/health` | System health status | None |
+| POST | `/auth/register` | Create user | None |
+| POST | `/auth/login` | Obtain JWT tokens | None |
+| POST | `/auth/refresh` | Refresh access token | Refresh token |
+| POST | `/auth/logout` | Revoke refresh token | Bearer |
+| POST | `/recommendations` | Get book recommendations | Bearer |
+| POST | `/admin/experiments` | Create A/B experiment | Admin |
+| GET | `/admin/experiments/{id}/results` | Experiment results | Admin |
+| POST | `/metrics/interaction` | Record user metric | Bearer |
+| GET | `/news/health` | News engine health | None |
+| POST | `/news/feed/personalized` | Personalized news feed | Bearer |
+| POST | `/news/summarize` | Summarize articles | Bearer |
+| GET | `/news/trending` | Trending topics | None |
+| POST | `/news/search` | Intelligent search | None |
+| POST | `/news/feedback` | Submit feedback | Bearer |
+| GET | `/news/analytics/user/{user_id}` | User analytics | Bearer |
+| POST | `/news/expand` | Expand news story | Bearer |
+| GET | `/news/stories/trending` | Trending expandable stories | None |
+| GET | `/news/expand/{article_id}` | Quick expand by ID | None |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,37 @@
+# Architecture
+
+## Component Overview
+```mermaid
+graph TD
+  A[User Browser] --> B[React/Vite Frontend]
+  B -->|REST| C[FastAPI Backend]
+  C -->|Query| D[(PostgreSQL)]
+  C -->|Cache| E[(Redis)]
+  C -->|Model calls| F[ML Models]
+  C -->|News APIs| G[External News Sources]
+```
+
+## Recommendation Flow
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant F as Frontend
+  participant A as API
+  participant R as Redis
+  participant M as Model
+
+  U->>F: Request recommendations
+  F->>A: POST /recommendations
+  A->>R: Check cache
+  alt Cache miss
+    A->>M: Generate suggestions
+    M-->>A: Book list
+    A->>R: Store cached result
+  end
+  A-->>F: RecommendationResponse
+  F-->>U: Render books
+```
+
+## Deployment
+- Docker Compose for local and monitoring stacks
+- Kubernetes (via Terraform modules) for production

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,15 @@
+# Benchmarks
+
+| Target | Command | Notes |
+|--------|---------|-------|
+| Frontend load | `npm run performance` | Uses `scripts/performance_analytics.py` for dashboard metrics |
+| API response time | `python scripts/performance_analytics.py` | Goal: <200ms for `/recommendations` |
+| News expansion latency | `pytest tests/news/test_news_expansion_comprehensive.py -k benchmark` | Expect <1s per article |
+
+## Known Bottlenecks
+- Cold-start model loading in `src/models/model_manager.py`
+- Expensive news expansion when external APIs are slow
+
+## Tips
+- Warm Redis cache before load tests
+- Use Node 18+ and Python 3.10+

--- a/CODEMAP.md
+++ b/CODEMAP.md
@@ -1,0 +1,29 @@
+# Code Map
+
+```text
+src/
+  api/                # FastAPI application and routes
+  auth/               # JWT auth, roles, permissions
+  components/         # React dashboard components
+  analytics/          # Real-time metrics and A/B testing helpers
+  core/               # config, logging, monitoring utilities
+  hooks/              # React hooks
+  models/             # ML models and managers
+  news/               # News intelligence and expansion APIs
+  services/           # Frontend service clients
+  stores/             # Redux/Zustand state containers
+  utils/              # Shared utilities
+  workers/            # Background jobs
+
+tests/
+  frontend/           # Vitest component tests
+  backend/            # pytest API tests
+  news/               # news engine tests
+
+scripts/              # Dev and analytics scripts
+terraform/            # Infrastructure as code modules
+```
+
+## Entrypoints
+- Frontend: `src/main.tsx`
+- Backend API: `src/api/main.py`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,3 +387,20 @@ Thank you for contributing to GoodBooks Recommender! 🎉
 ---
 
 *This contributing guide is maintained by the project maintainers and is updated regularly to reflect current best practices and community needs.*
+
+---
+## Quick Commands
+```bash
+npm test             # Run frontend tests
+python -m pytest     # Run backend tests
+npm run lint         # Lint frontend
+pre-commit run --files <path>  # Lint backend
+```
+
+## Issue Triage Labels
+Use labels like `bug`, `feature`, `documentation`, `good-first-issue` to help prioritization.
+
+## Commit & PR Conventions
+- Commits follow `type(scope): short description`
+- Reference issues with `Fixes #123`
+- Include test and doc updates with code changes

--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -1,0 +1,18 @@
+# Data Model
+
+| Model | Fields (key) | Notes |
+|-------|--------------|-------|
+| `auth.security.User` | `id`, `email`, `role`, `hashed_password` | Stored in PostgreSQL via SQLAlchemy |
+| `auth.security.TokenData` | `sub`, `exp`, `scope` | JWT payload |
+| `api.main.RecommendationRequest` | `user_id`, `book_title`, `n_recommendations` | Request body for `/recommendations` |
+| `api.main.BookRecommendation` | `title`, `author`, `score`, `explanation` | Returned recommendation item |
+| `api.main.HealthCheckResponse` | `status`, `checks` | Detailed health info |
+| `analytics.real_time_analytics.RealTimeMetrics` | `experiment_id`, `metric_name`, `value` | A/B test metrics |
+| `news.api.endpoints.PersonalizedFeedRequest` | `user_id`, `topics`, `limit` | Input for news feed |
+| `news.api.news_expansion.NewsExpansionRequest` | `article_id`, `article_url`, `summary_level` | Expand news story |
+| Cache entries | Various keys | Stored in Redis with TTL |
+
+## Storage
+- **PostgreSQL**: users, books, interactions
+- **Redis**: caching and sessions
+- **Vector store**: optional embedding storage for recommendations

--- a/PROJECT_BRIEF.md
+++ b/PROJECT_BRIEF.md
@@ -1,0 +1,24 @@
+# GoodBooks Recommender – Project Brief
+
+## Purpose
+AI-first platform that recommends books and curated news through a React/TypeScript dashboard backed by a Python FastAPI service.
+
+## Domain
+- Book and article recommendations
+- News expansion and summarization
+- User analytics and A/B experiments
+
+## Key Flows
+1. User signs in with JWT-based auth
+2. Frontend requests recommendations and news feed
+3. Backend serves data, caching results in Redis and persisting in PostgreSQL
+4. Analytics and experiments recorded for real-time dashboards
+
+## Public Interfaces
+- **Web UI**: `dashboard/index.html`
+- **REST API**: `src/api/main.py`, `src/news/api/*`
+
+## Environments
+- **Local**: `docker-compose.yml`
+- **Monitoring**: `docker-compose.monitoring.yml`
+- **Production**: Kubernetes manifests (not in repo) driven by Terraform in `terraform/`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Notes
+
+## ASVS L2 Checklist
+| Control | Status | Notes |
+|---------|--------|-------|
+| Authentication requires JWT with RBAC | Pass | See `src/auth/security.py` |
+| Refresh tokens stored server-side | Pass | Redis blacklisting in `src/auth/security.py` |
+| Session timeout and revocation | Pass | Tokens carry `exp` claims |
+| Passwords hashed with bcrypt | Pass | `src/auth/security.py` lines 34-35 |
+| Input validation on API models | Pass | Pydantic models in `src/api/main.py` |
+| Output encoding for templates | N/A | No server-side rendering |
+| Error handling avoids leaks | Pass | Central handler in `src/api/main.py` |
+| Security headers set | Gap | No explicit `SecurityMiddleware` |
+| HTTPS enforcement | Gap | Handled by reverse proxy not shown |
+| Logging with request IDs | Pass | `src/core/enhanced_logging.py` |
+| Dependency scanning | Gap | No automated vulnerability scan in CI |
+| CSRF protection | N/A | Pure API with JWT |
+| Deserialization security | Pass | Only Pydantic parsing |
+| SSRF protections for external calls | Gap | External requests not validated |
+| Secrets management | Gap | `.env.example` recommends manual entry |
+| Rate limiting | Gap | No rate limit middleware |
+
+## Secret Handling
+- Do not commit real credentials; use `.env.example` as template.
+- Rotate JWT signing key and database passwords regularly.
+
+## Dependency Risks
+- Review `requirements.txt` and `package.json` for outdated packages.

--- a/TEST_MATRIX.md
+++ b/TEST_MATRIX.md
@@ -1,0 +1,16 @@
+# Test Matrix
+
+| Area | Framework | Location | Coverage | Gaps |
+|------|-----------|----------|----------|------|
+| Frontend components | Vitest | `tests/frontend` | ~60% (estimate) | Missing tests for complex animations and 3D scenes |
+| Backend API | pytest | `tests/backend`, `test_api.py` | ~70% | Limited error-path and auth failure tests |
+| News engine | pytest | `tests/news` | moderate | No load tests for expansion endpoints |
+| E2E dashboard | (none) | N/A | 0% | No Cypress tests configured |
+| Terraform modules | terraform validate | `terraform/` | manual | No automated plan test |
+
+## Recommended Additions
+- Smoke test hitting `/health` and `/news/health`
+- Integration test for cache behavior in `/recommendations`
+- Frontend test for store persistence
+- Security test for auth role restrictions
+- Terraform unit tests with `terraform validate` in CI


### PR DESCRIPTION
## Summary
- add repo overview docs: PROJECT_BRIEF, CODEMAP, ARCHITECTURE
- catalogue APIs, data models, tests, security and benchmarks
- add CODEOWNERS and scoped Copilot instructions
- add AGENTS handbook and link to instructions

## Testing
- `npm test` *(fails: Failed to load module '@testing-library/jest-dom')*
- `npm run lint` *(fails: ESLint couldn't find config '@typescript-eslint/recommended')*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pre-commit run --files AGENTS.md .github/copilot-instructions.md .github/prompts/repo-context.md` *(fails: command not found: pre-commit)*
- `terraform validate` *(fails: command not found: terraform)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f82e9548330b328928eca8abe45